### PR TITLE
KO-488 Rollback cass 40 defs to beta1

### DIFF
--- a/resources/cassandra-yaml/cassandra/cassandra-yaml-cassandra-4.0.0.edn
+++ b/resources/cassandra-yaml/cassandra/cassandra-yaml-cassandra-4.0.0.edn
@@ -348,17 +348,18 @@
    :fields
    {:class_name {:type "string"},
     :parameters {:type "user_defined", :value_type "string"}}}
-  :replica_filtering_protection
-  {:type "dict"
-   :order [:cached_rows_warn_threshold
-           :cached_rows_fail_threshold]
-   :fields
-   {:cached_rows_warn_threshold 
-    {:type "int"
-     :default_value 2000}
-    :cached_rows_fail_threshold
-    {:type "int"
-     :default_value 32000}}}},
+  ; :replica_filtering_protection
+  ; {:type "dict"
+  ;  :order [:cached_rows_warn_threshold
+  ;          :cached_rows_fail_threshold]
+  ;  :fields
+  ;  {:cached_rows_warn_threshold 
+  ;   {:type "int"
+  ;    :default_value 2000}
+  ;   :cached_rows_fail_threshold
+  ;   {:type "int"
+  ;    :default_value 32000}}}
+     },
  :groupings
  [{:name "Security",
    :list
@@ -454,7 +455,8 @@
   {:name "Change Data Capture", :list ["cdc_enabled"]}
   {:name "Miscellaneous",
    :list
-   ["replica_filtering_protection"
+   [
+    ;  "replica_filtering_protection"
     "disk_failure_policy"
     "commit_failure_policy"
     "trickle_fsync"


### PR DESCRIPTION
Made defs on cassandra trunk when cassandra-4.0-beta1 tag should have been used. Rollback based on:

```
git diff trunk cassandra-4.0-beta1 -- conf/
```
